### PR TITLE
Fix advanced thruster fuel/oxidizer when not merging hydraulic/hydro plants

### DIFF
--- a/compat/planets.lua
+++ b/compat/planets.lua
@@ -36,6 +36,15 @@ if mods["maraxsis"] then
         add_crafting_categories("assembling-machine", "maraxsis-hydro-plant", {"hydraulics", "hydraulics-or-chemistry", "hydraulics-or-organic", "hydraulics-or-chemistry-or-cryogenics", "synthesis-or-chemistry"})
         data.raw["assembling-machine"]["maraxsis-hydro-plant"].effect_receiver = { base_effect = { productivity = 0.25, quality = 2.5 }}
         data.raw.technology["aop-specialized-science"].prerequisites = {"aop-armory", "aop-petrochemistry", "aop-hybridation", "cryogenic-science-pack", "maraxsis-deepsea-research"}
+    else
+        -- fix missing advanced thruster fuel/oxidizer recipes
+        data:extend{{type="recipe-category", name="maraxsis-hydro-plant-or-hydraulics-or-chemistry"}}
+        add_crafting_categories("assembling-machine", "aop-hydraulic-plant", {"maraxsis-hydro-plant-or-hydraulics-or-chemistry"})
+        add_crafting_categories("assembling-machine", "maraxsis-hydro-plant", {"maraxsis-hydro-plant-or-hydraulics-or-chemistry", "synthesis-or-chemistry"}) -- also add stone/calcite synthesis to maraxis hydro plant
+        local recipesToMove = {"advanced-thruster-fuel","advanced-thruster-oxidizer"}
+        for _,rec in pairs(recipesToMove) do
+            data.raw.recipe[rec].category_id = "maraxsis-hydro-plant-or-hydraulics-or-chemistry"
+        end
     end
     
     data.raw.technology["aop-core-mining"].prerequisites = {"aop-electromechanics", "promethium-science-pack", "maraxsis-project-seadragon"}

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,7 +8,7 @@ description=Adding new machines to Space Age for more variety and bigger product
 aop-merge-hydro=Merge hydro and hydraulic plant
 
 [mod-setting-description]
-aop-merge-hydro=Remove the hydro plant, add its recipes to the hydraulic plant and modify it to 25% prod/25% quality.
+aop-merge-hydro=Remove the hydraulic plant, adding its recipes to the hydro plant and modifying it to be a hybrid of both at 25% prod/25% quality.
 
 [technology-name]
 aop-air-scrubbing=Air Scrubbing


### PR DESCRIPTION
Fix advanced thruster fuel/oxidizer for hydraulic plant
Also fixes the mod setting description introduced in the last PR.