### PR TITLE
Fixes tech prerequisites for aop-arc-furnace

### DIFF
--- a/compat/aai.lua
+++ b/compat/aai.lua
@@ -16,6 +16,11 @@ local function add_tech_effect(tech_name, effect)
   local function add_tech_prerequisites(tech_name, prerequisites)
     local tech = data.raw.technology[tech_name]
     tech.prerequisites = tech.prerequisites or {}
+    for _, prereq in ipairs(tech.prerequisites) do
+      if prereq == prerequisites then
+        return
+      end
+    end
     table.insert(tech.prerequisites, prerequisites)
   end
 

--- a/compat/aai.lua
+++ b/compat/aai.lua
@@ -43,5 +43,6 @@ data.raw.recipe["aop-arc-furnace"].ingredients = {
 }
 add_tech_prerequisites("aop-arc-furnace", "industrial-furnace")
 if mods["corrundum"] then 
-    add_tech_prerequisites("aop-arc-furnace", {"electrochemical-science-pack", "industrial-furnace"})
+    add_tech_prerequisites("aop-arc-furnace", "electrochemical-science-pack")
+    add_tech_prerequisites("aop-arc-furnace",  "industrial-furnace")
 end

--- a/compat/planets.lua
+++ b/compat/planets.lua
@@ -4,11 +4,17 @@ local function add_tech_effect(tech_name, effect)
     table.insert(tech.effects, effect)
   end
 
-local function add_tech_prerequisites(tech_name, prerequisites)
+  local function add_tech_prerequisites(tech_name, prerequisites)
     local tech = data.raw.technology[tech_name]
     tech.prerequisites = tech.prerequisites or {}
+    for _, prereq in ipairs(tech.prerequisites) do
+      if prereq == prerequisites then
+        return
+      end
+    end
     table.insert(tech.prerequisites, prerequisites)
   end
+
 
   local function add_science_pack(tech_name, science_pack)
     local tech = data.raw.technology[tech_name]


### PR DESCRIPTION
Replaces the adding of prerequisites as a table and adds rudimentary duplicate check. Works for me with aai and corrundum, haven't checked other setups.