### PR TITLE
Dirty fix for maraxsis 1.30.41 update 

### DIFF
--- a/compat/planets.lua
+++ b/compat/planets.lua
@@ -55,7 +55,11 @@ if mods["maraxsis"] then
         data.raw["recipe"]["aop-hydraulic-plant-recycling"] = nil
         data.raw["technology"]["aop-hydraulics"].hidden = true
         data.raw["assembling-machine"]["maraxsis-hydro-plant"].effect_receiver = { base_effect = { productivity = 0.25, quality = 2.5 }}
-        data.raw.technology["aop-core-mining"].prerequisites = { "aop-electromechanics", "promethium-science-pack", "maraxsis-deepsea-research" }
+        if mods["Krastorio2-spaced-out"] then 
+            data.raw.technology["aop-core-mining"].prerequisites = { "aop-electromechanics", "promethium-science-pack", "maraxsis-research-vessel" }
+        else
+            data.raw.technology["aop-core-mining"].prerequisites = { "aop-electromechanics", "promethium-science-pack", "maraxsis-deepsea-research" }
+        end
         if settings.startup["aop-specialized-science"].value then
             if mods["Krastorio2-spaced-out"] then 
                 data.raw.technology["aop-specialized-science"].prerequisites = { "aop-armory", "aop-petrochemistry", "aop-hybridation", "maraxsis-research-vessel" }


### PR DESCRIPTION
If k2so enabled maraxsis-deepsea-research may become not exist.Add checking trigger to dirty swap.