### PR TITLE
Advanced assembling machine standardized fluidboxes

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -28,11 +28,3 @@ if mods["scraptk"] then
     ScrapIndustry.categories["advanced-smelting"] = {ignore=true}
 end
 
--- very temp literally joke code
-data.raw.planet["nauvis"].platform_surface_render_parameters.platform_backdrop.planet_surface={
-      filename = "__Age-of-Production__/mario-earth.png",
-      width = 2048,
-      height = 1024
-    }
-data.raw.planet["nauvis"].platform_surface_render_parameters.platform_backdrop.planet_normal=nil
-data.raw.planet["nauvis"].platform_surface_render_parameters.platform_backdrop.planet_reflectivity=nil

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -865,15 +865,8 @@ data:extend {{
         pipe_covers = pipecoverspictures(),
             secondary_draw_orders = { north = -1 },
             volume = 1000,
-            pipe_connections = { { flow_direction = "input", direction = defines.direction.north, position = { -1, -2 } } }
-        },
-        {
-            production_type = "input",
-            pipe_picture = require("__base__/prototypes/entity/assembler-pictures").assembler2pipepictures,
-        pipe_covers = pipecoverspictures(),
-            secondary_draw_orders = { north = -1 },
-            volume = 1000,
-            pipe_connections = { { flow_direction = "input", direction = defines.direction.north, position = { 1, -2 } } }
+            pipe_connections = { { flow_direction = "input", direction = defines.direction.north, position = { -1, -2 } } ,
+            { flow_direction = "input", direction = defines.direction.north, position = { 1, -2 } } }
         },
         {
             production_type = "output",
@@ -881,16 +874,9 @@ data:extend {{
         pipe_covers = pipecoverspictures(),
             secondary_draw_orders = { north = -1 },
             volume = 500,
-            pipe_connections = { { flow_direction = "output", direction = defines.direction.south, position = { -1, 2 } } }
-        },
-        {
-            production_type = "output",
-            pipe_picture = require("__base__/prototypes/entity/assembler-pictures").assembler2pipepictures,
-        pipe_covers = pipecoverspictures(),
-            secondary_draw_orders = { north = -1 },
-            volume = 500,
-            pipe_connections = { { flow_direction = "output", direction = defines.direction.south, position = { 1, 2 } } }
-        },
+            pipe_connections = { { flow_direction = "output", direction = defines.direction.south, position = { -1, 2 } } ,
+             { flow_direction = "output", direction = defines.direction.south, position = { 1, 2 } } }
+        }
       },
         fluid_boxes_off_when_no_fluid_recipe = true,
         crafting_speed = 2,


### PR DESCRIPTION
This PR changes the fluidboxes of the advanced assembling machine to match those of standard assembling machines, which have exactly one fluidbox input and one fluidbox output. This is intended to improve compatibility with Muluna, which requires assembling machines have exactly one fluidbox input and one fluid output fluidbox.